### PR TITLE
Updated for MW 1.32 compatibility.

### DIFF
--- a/CustomNavBlocks.php
+++ b/CustomNavBlocks.php
@@ -28,7 +28,7 @@ function addCustomNavBlocks($skin, $tpl) {
 
     $parserOptions = new ParserOptions();
 
-    $CustomNavBlocksRaw = $tpl->translator->translate('CustomNavBlocks');
+    $CustomNavBlocksRaw = wfMessage('CustomNavBlocks')->text();
     $CustomNavBlocksClean = trim(preg_replace(
         array('/<!--(.*)-->/s'), array(''), $CustomNavBlocksRaw));
     $blocks = explode("\n", $CustomNavBlocksClean);
@@ -69,9 +69,9 @@ function addCustomNavBlocks($skin, $tpl) {
                 }
             } else {
                 # get article and content:
-                $content = $tpl->translator->translate("$definition");
-
-                # parse the mediawiki-syntax into html:
+                $content = wfMessage("$definition")->text();
+                
+		# parse the mediawiki-syntax into html:
                 $content = $wgParser->preprocess(
                     $content, $title, $parserOptions);
                 $parserOutput = $wgParser->parse(


### PR DESCRIPTION
The $translator variable was removed from the QuickTemplate class in MW 1.32 causing lines 43 and 76 to throw exceptions in MW 1.32. Additionally, the entire MediaWikiI18N class is now deprecated.

To fix this, I've replaced the two `$tpl->translator->translate()` calls with calls to `wfMessage()->text()` instead.

